### PR TITLE
[add] #79 プロフィール編集を実装

### DIFF
--- a/lib/screens/profile_screen.dart
+++ b/lib/screens/profile_screen.dart
@@ -49,7 +49,7 @@ class _ProfileScreenState extends State<ProfileScreen> {
             children: [
               const SizedBox(height: 24),
               _myself != null
-                  ? ProfileField(user: _myself!)
+                  ? ProfileField(uid: widget.uid, user: _myself!)
                   : Center(child: CircularProgressIndicator()),
               const SizedBox(height: 24),
               SimpleDivider(),

--- a/lib/widgets/profile_screen/action_button.dart
+++ b/lib/widgets/profile_screen/action_button.dart
@@ -1,3 +1,4 @@
+import 'package:dish/models/User.dart';
 import 'package:flutter/material.dart';
 
 import 'package:dish/configs/constant_colors.dart';
@@ -6,10 +7,14 @@ import 'package:dish/screens/edit_profile_screen.dart';
 class ActionButton extends StatefulWidget {
   ActionButton({
     Key? key,
+    required this.uid,
+    required this.user,
     required this.userType,
     required this.setUserType,
   });
 
+  final User user;
+  final String uid;
   final String userType;
   final void Function(String) setUserType;
 
@@ -57,7 +62,7 @@ class _ActionButtonState extends State<ActionButton> {
               Navigator.push(
                 context,
                 MaterialPageRoute(builder: (_) {
-                  return EditProfileScreen();
+                  return EditProfileScreen(uid: widget.uid, user: widget.user);
                 }),
               );
             },

--- a/lib/widgets/profile_screen/profile_field.dart
+++ b/lib/widgets/profile_screen/profile_field.dart
@@ -12,9 +12,11 @@ import 'package:dish/widgets/profile_screen/action_button.dart';
 class ProfileField extends StatefulWidget {
   ProfileField({
     Key? key,
+    required this.uid,
     required this.user,
   });
 
+  final String uid;
   final User user;
 
   @override
@@ -45,6 +47,7 @@ class _ProfileFieldState extends State<ProfileField> {
 
   @override
   Widget build(BuildContext context) {
+    final String uid = widget.uid;
     final User user = widget.user;
 
     return Padding(
@@ -139,16 +142,24 @@ class _ProfileFieldState extends State<ProfileField> {
           ),
           const SizedBox(height: 12),
           // プロフィールテキスト
-          Text(
-            user.profileText,
-            style: TextStyle(
-              fontSize: 12,
-              color: AppColor.kPrimaryTextColor,
+          SizedBox(
+            width: double.infinity,
+            child: Text(
+              user.profileText,
+              style: TextStyle(
+                fontSize: 13,
+                color: AppColor.kPrimaryTextColor,
+              ),
             ),
           ),
           const SizedBox(height: 24),
           // ボタン
-          ActionButton(userType: _userType, setUserType: setUserType),
+          ActionButton(
+            uid: uid,
+            user: user,
+            userType: _userType,
+            setUserType: setUserType,
+          ),
           // 一時的なログアウトボタン
           Container(
             height: 36,


### PR DESCRIPTION
プロフィールテキスト以外の項目は、空欄の場合は変更前の値を参照する。

変更後のユーザーIDが他のユーザーと被る場合はそれに変更できない。

