### PR TITLE
[add] フォローフォロワー一覧を表示する

### DIFF
--- a/lib/models/User.dart
+++ b/lib/models/User.dart
@@ -1,9 +1,11 @@
 // 仮のデータ構造
 class User {
+  final String? uid;
   final String userId, userName, profileText, iconImageUrl;
   final int? followCount, followerCount, postCount;
 
   User({
+    this.uid,
     required this.userId,
     required this.userName,
     required this.profileText,
@@ -15,6 +17,7 @@ class User {
 }
 
 final testUser = User(
+  uid: "",
   userId: "TestUserName",
   userName: "苗字 名前",
   profileText:

--- a/lib/screens/follow_list_screen.dart
+++ b/lib/screens/follow_list_screen.dart
@@ -56,6 +56,7 @@ class _FollowListScreenState extends State<FollowListScreen> {
         await FirebaseFirestore.instance.collection("USERS").doc(uid).get();
     final data = snapshot.data() as Map<String, dynamic>;
     User user = User(
+      uid: uid,
       iconImageUrl: data["icon_path"],
       userId: data["user_id"],
       userName: data["user_name"],

--- a/lib/screens/follow_list_screen.dart
+++ b/lib/screens/follow_list_screen.dart
@@ -1,11 +1,18 @@
 import 'package:flutter/material.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
 
+import 'package:dish/models/User.dart';
 import 'package:dish/configs/constant_colors.dart';
 import 'package:dish/widgets/common/simple_divider.dart';
 import 'package:dish/widgets/follow_follower_list_screen/user_card.dart';
 
 class FollowListScreen extends StatefulWidget {
-  const FollowListScreen({Key? key}) : super(key: key);
+  const FollowListScreen({
+    Key? key,
+    required this.uid,
+  }) : super(key: key);
+
+  final String uid;
 
   @override
   _FollowListScreenState createState() => _FollowListScreenState();
@@ -13,22 +20,71 @@ class FollowListScreen extends StatefulWidget {
 
 class _FollowListScreenState extends State<FollowListScreen> {
   final _title = "フォロー中";
+  List<String> _followIdList = [];
+  List<User> _userList = [];
+
+  @override
+  Future<void> didChangeDependencies() async {
+    super.didChangeDependencies();
+    await _getFollowIdList(widget.uid);
+    await _setUserList(_followIdList);
+  }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: _buildAppBar(context),
       body: SafeArea(
-        child: Container(
-          child: ListView(
-            children: [
-              UserCard(),
-              SimpleDivider(height: 1.0),
-            ],
-          ),
+        child: ListView.separated(
+          itemBuilder: (context, index) {
+            if (index == _userList.length) return SimpleDivider(height: 1.0);
+
+            return UserCard(
+              user: _userList[index],
+              isFollowed: true,
+            );
+          },
+          separatorBuilder: (_, __) => SimpleDivider(height: 1.0),
+          itemCount: _userList.length + 1,
         ),
       ),
     );
+  }
+
+  Future<User> _getUser(String uid) async {
+    DocumentSnapshot<Map<String, dynamic>> snapshot =
+        await FirebaseFirestore.instance.collection("USERS").doc(uid).get();
+    final data = snapshot.data() as Map<String, dynamic>;
+    User user = User(
+      iconImageUrl: data["icon_path"],
+      userId: data["user_id"],
+      userName: data["user_name"],
+      profileText: data["profile_text"],
+    );
+    return user;
+  }
+
+  Future<void> _setUserList(List<String> idList) async {
+    List<User> userList =
+        await Future.wait(idList.map((String id) => _getUser(id)));
+    setState(() {
+      _userList = userList;
+    });
+  }
+
+  Future<void> _getFollowIdList(String uid) async {
+    QuerySnapshot<Map<String, dynamic>> snapshot = await FirebaseFirestore
+        .instance
+        .collection("FOLLOW_FOLLOWER")
+        .where("followee_id", isEqualTo: widget.uid)
+        .get();
+    final List<String> followIdList = snapshot.docs.map((doc) {
+      final data = doc.data();
+      return data["follower_id"] as String;
+    }).toList();
+    setState(() {
+      _followIdList = followIdList;
+    });
   }
 
   AppBar _buildAppBar(BuildContext context) {

--- a/lib/screens/follower_list_screen.dart
+++ b/lib/screens/follower_list_screen.dart
@@ -1,11 +1,18 @@
 import 'package:flutter/material.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
 
+import 'package:dish/models/User.dart';
 import 'package:dish/configs/constant_colors.dart';
 import 'package:dish/widgets/common/simple_divider.dart';
 import 'package:dish/widgets/follow_follower_list_screen/user_card.dart';
 
 class FollowerListScreen extends StatefulWidget {
-  const FollowerListScreen({Key? key}) : super(key: key);
+  const FollowerListScreen({
+    Key? key,
+    required this.uid,
+  }) : super(key: key);
+
+  final String uid;
 
   @override
   _FollowerListScreenState createState() => _FollowerListScreenState();
@@ -13,22 +20,74 @@ class FollowerListScreen extends StatefulWidget {
 
 class _FollowerListScreenState extends State<FollowerListScreen> {
   final _title = "フォロワー";
+  List<String> _followerIdList = [];
+  List<User> _userList = [];
+
+  @override
+  Future<void> didChangeDependencies() async {
+    super.didChangeDependencies();
+    await _getFollowerIdList(widget.uid);
+    await _setUserList(_followerIdList);
+  }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: _buildAppBar(context),
       body: SafeArea(
-        child: Container(
-          child: ListView(
-            children: [
-              UserCard(),
-              SimpleDivider(height: 1.0),
-            ],
-          ),
+        child: ListView.separated(
+          itemBuilder: (context, index) {
+            if (index == _userList.length) return SimpleDivider(height: 1.0);
+
+            return UserCard(
+              user: _userList[index],
+              isFollowed: false,
+            );
+          },
+          separatorBuilder: (_, __) => SimpleDivider(height: 1.0),
+          itemCount: _userList.length + 1,
         ),
       ),
     );
+  }
+
+  Future<User> _getUser(String uid) async {
+    DocumentSnapshot<Map<String, dynamic>> snapshot = await FirebaseFirestore
+        .instance
+        .collection("USERS")
+        .doc(widget.uid)
+        .get();
+    final data = snapshot.data() as Map<String, dynamic>;
+    User user = User(
+      iconImageUrl: data["icon_path"],
+      userId: data["user_id"],
+      userName: data["user_name"],
+      profileText: data["profile_text"],
+    );
+    return user;
+  }
+
+  Future<void> _setUserList(List<String> idList) async {
+    List<User> userList =
+        await Future.wait(idList.map((String id) => _getUser(id)));
+    setState(() {
+      _userList = userList;
+    });
+  }
+
+  Future<void> _getFollowerIdList(String uid) async {
+    QuerySnapshot<Map<String, dynamic>> snapshot = await FirebaseFirestore
+        .instance
+        .collection("FOLLOW_FOLLOWER")
+        .where("follower_id", isEqualTo: widget.uid)
+        .get();
+    final List<String> followerIdList = snapshot.docs.map((doc) {
+      final data = doc.data();
+      return data["followee_id"] as String;
+    }).toList();
+    setState(() {
+      _followerIdList = followerIdList;
+    });
   }
 
   AppBar _buildAppBar(BuildContext context) {

--- a/lib/widgets/follow_follower_list_screen/user_card.dart
+++ b/lib/widgets/follow_follower_list_screen/user_card.dart
@@ -1,16 +1,23 @@
+import 'package:dish/models/User.dart';
 import 'package:flutter/material.dart';
 
 import 'package:dish/configs/constant_colors.dart';
 
 class UserCard extends StatefulWidget {
-  const UserCard({Key? key}) : super(key: key);
+  UserCard({
+    Key? key,
+    required this.user,
+    required this.isFollowed,
+  }) : super(key: key);
+
+  final User user;
+  bool isFollowed;
 
   @override
   _UserCardState createState() => _UserCardState();
 }
 
 class _UserCardState extends State<UserCard> {
-  bool isFollowed = false;
   final _followedLabel = "フォロー中";
   final _notFollowedLabel = "フォロー";
 
@@ -39,7 +46,7 @@ class _UserCardState extends State<UserCard> {
             child: ClipRRect(
               borderRadius: BorderRadius.all(Radius.circular(50)),
               child: Image.network(
-                "https://i.pinimg.com/474x/9b/47/a0/9b47a023caf29f113237d61170f34ad9.jpg",
+                widget.user.iconImageUrl,
                 fit: BoxFit.cover,
               ),
             ),
@@ -50,14 +57,14 @@ class _UserCardState extends State<UserCard> {
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               Text(
-                "苗字 名前",
+                widget.user.userName,
                 style: TextStyle(
                   color: AppColor.kPrimaryTextColor,
                   fontSize: 12,
                 ),
               ),
               Text(
-                "UserName",
+                widget.user.userId,
                 style: TextStyle(
                   color: AppColor.kPrimaryTextColor,
                   fontWeight: FontWeight.bold,
@@ -67,7 +74,7 @@ class _UserCardState extends State<UserCard> {
             ],
           ),
           Spacer(),
-          isFollowed
+          widget.isFollowed
               ? Container(
                   width: 88,
                   height: 32,
@@ -90,7 +97,7 @@ class _UserCardState extends State<UserCard> {
                     onPressed: () {
                       setState(() {
                         // フォロー解除処理
-                        isFollowed = false;
+                        widget.isFollowed = false;
                       });
                     },
                   ),
@@ -116,7 +123,7 @@ class _UserCardState extends State<UserCard> {
                     onPressed: () {
                       setState(() {
                         // フォロー処理
-                        isFollowed = true;
+                        widget.isFollowed = true;
                       });
                     },
                   ),

--- a/lib/widgets/follow_follower_list_screen/user_card.dart
+++ b/lib/widgets/follow_follower_list_screen/user_card.dart
@@ -1,6 +1,7 @@
-import 'package:dish/models/User.dart';
 import 'package:flutter/material.dart';
 
+import 'package:dish/models/User.dart';
+import 'package:dish/screens/profile_screen.dart';
 import 'package:dish/configs/constant_colors.dart';
 
 class UserCard extends StatefulWidget {
@@ -32,22 +33,31 @@ class _UserCardState extends State<UserCard> {
       child: Row(
         crossAxisAlignment: CrossAxisAlignment.center,
         children: [
-          Container(
-            height: 45,
-            width: 45,
-            decoration: BoxDecoration(
-              color: Colors.white,
-              shape: BoxShape.circle,
-              border: Border.all(
-                color: AppColor.kPinkColor,
-                width: 2,
+          GestureDetector(
+            onTap: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                    builder: (_) => ProfileScreen(uid: widget.user.uid!)),
+              );
+            },
+            child: Container(
+              height: 45,
+              width: 45,
+              decoration: BoxDecoration(
+                color: Colors.white,
+                shape: BoxShape.circle,
+                border: Border.all(
+                  color: AppColor.kPinkColor,
+                  width: 2,
+                ),
               ),
-            ),
-            child: ClipRRect(
-              borderRadius: BorderRadius.all(Radius.circular(50)),
-              child: Image.network(
-                widget.user.iconImageUrl,
-                fit: BoxFit.cover,
+              child: ClipRRect(
+                borderRadius: BorderRadius.all(Radius.circular(50)),
+                child: Image.network(
+                  widget.user.iconImageUrl,
+                  fit: BoxFit.cover,
+                ),
               ),
             ),
           ),

--- a/lib/widgets/profile_screen/profile_field.dart
+++ b/lib/widgets/profile_screen/profile_field.dart
@@ -111,7 +111,7 @@ class _ProfileFieldState extends State<ProfileField> {
                       Navigator.push(
                         context,
                         MaterialPageRoute(builder: (_) {
-                          return FollowerListScreen();
+                          return FollowerListScreen(uid: widget.uid);
                         }),
                       );
                     },
@@ -131,7 +131,7 @@ class _ProfileFieldState extends State<ProfileField> {
                       Navigator.push(
                         context,
                         MaterialPageRoute(builder: (_) {
-                          return FollowListScreen();
+                          return FollowListScreen(uid: widget.uid);
                         }),
                       );
                     },


### PR DESCRIPTION
フォローフォロワーの一覧をFirestoreから取得して動的に生成する。

また、一覧からアイコン画像をタップすることで、そのユーザーのプロフィール画面に遷移できるようにした。