### PR TITLE
[add] フォロー・フォロー解除ボタンの出し分け

### DIFF
--- a/lib/screens/follow_list_screen.dart
+++ b/lib/screens/follow_list_screen.dart
@@ -21,7 +21,7 @@ class FollowListScreen extends StatefulWidget {
 class _FollowListScreenState extends State<FollowListScreen> {
   final _title = "フォロー中";
   List<String> _followIdList = [];
-  List<User> _userList = [];
+  List<Map> _userList = [];
 
   @override
   Future<void> didChangeDependencies() async {
@@ -40,8 +40,8 @@ class _FollowListScreenState extends State<FollowListScreen> {
             if (index == _userList.length) return SimpleDivider(height: 1.0);
 
             return UserCard(
-              user: _userList[index],
-              isFollowed: true,
+              user: _userList[index]["user"],
+              didFollow: _userList[index]["didFollow"],
               myselfUid: widget.uid,
             );
           },
@@ -52,7 +52,7 @@ class _FollowListScreenState extends State<FollowListScreen> {
     );
   }
 
-  Future<User> _getUser(String uid) async {
+  Future<Map> _getUser(String uid) async {
     DocumentSnapshot<Map<String, dynamic>> snapshot =
         await FirebaseFirestore.instance.collection("USERS").doc(uid).get();
     final data = snapshot.data() as Map<String, dynamic>;
@@ -63,11 +63,12 @@ class _FollowListScreenState extends State<FollowListScreen> {
       userName: data["user_name"],
       profileText: data["profile_text"],
     );
-    return user;
+
+    return {"didFollow": true, "user": user};
   }
 
   Future<void> _setUserList(List<String> idList) async {
-    List<User> userList =
+    List<Map> userList =
         await Future.wait(idList.map((String id) => _getUser(id)));
     setState(() {
       _userList = userList;

--- a/lib/screens/follow_list_screen.dart
+++ b/lib/screens/follow_list_screen.dart
@@ -110,16 +110,6 @@ class _FollowListScreenState extends State<FollowListScreen> {
           fontSize: 16,
         ),
       ),
-      actions: [
-        GestureDetector(
-          onTap: () {},
-          child: Icon(
-            Icons.more_horiz,
-            color: AppColor.kPrimaryTextColor,
-          ),
-        ),
-        const SizedBox(width: 12),
-      ],
     );
   }
 }

--- a/lib/screens/follower_list_screen.dart
+++ b/lib/screens/follower_list_screen.dart
@@ -57,7 +57,7 @@ class _FollowerListScreenState extends State<FollowerListScreen> {
         await FirebaseFirestore.instance.collection("USERS").doc(uid).get();
     final data = snapshot.data() as Map<String, dynamic>;
     User user = User(
-      uid: widget.uid,
+      uid: uid,
       iconImageUrl: data["icon_path"],
       userId: data["user_id"],
       userName: data["user_name"],

--- a/lib/screens/follower_list_screen.dart
+++ b/lib/screens/follower_list_screen.dart
@@ -109,16 +109,6 @@ class _FollowerListScreenState extends State<FollowerListScreen> {
           fontSize: 16,
         ),
       ),
-      actions: [
-        GestureDetector(
-          onTap: () {},
-          child: Icon(
-            Icons.more_horiz,
-            color: AppColor.kPrimaryTextColor,
-          ),
-        ),
-        const SizedBox(width: 12),
-      ],
     );
   }
 }

--- a/lib/widgets/follow_follower_list_screen/user_card.dart
+++ b/lib/widgets/follow_follower_list_screen/user_card.dart
@@ -22,6 +22,7 @@ class UserCard extends StatefulWidget {
 }
 
 Future<String> _followUser(String followerUid, String followeeUid) async {
+  print("$followeeUid, $followerUid");
   Future<String> res =
       FirebaseFirestore.instance.collection('FOLLOW_FOLLOWER').add({
     "follower_id": followerUid,
@@ -141,8 +142,8 @@ class _UserCardState extends State<UserCard> {
                       setState(() {
                         // フォロー解除処理
                         widget.didFollow = false;
-                        _unfollowUser(widget.myselfUid, widget.user.uid!);
                       });
+                      _unfollowUser(widget.user.uid!, widget.myselfUid);
                     },
                   ),
                 )
@@ -168,8 +169,8 @@ class _UserCardState extends State<UserCard> {
                       setState(() {
                         // フォロー処理
                         widget.didFollow = true;
-                        _followUser(widget.myselfUid, widget.user.uid!);
                       });
+                      _followUser(widget.user.uid!, widget.myselfUid);
                     },
                   ),
                 ),

--- a/lib/widgets/follow_follower_list_screen/user_card.dart
+++ b/lib/widgets/follow_follower_list_screen/user_card.dart
@@ -1,5 +1,5 @@
-import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
 
 import 'package:dish/models/User.dart';
 import 'package:dish/screens/profile_screen.dart';
@@ -9,12 +9,12 @@ class UserCard extends StatefulWidget {
   UserCard({
     Key? key,
     required this.user,
-    required this.isFollowed,
+    required this.didFollow,
     required this.myselfUid,
   }) : super(key: key);
 
   final User user;
-  bool isFollowed;
+  bool didFollow;
   final String myselfUid;
 
   @override
@@ -117,7 +117,7 @@ class _UserCardState extends State<UserCard> {
             ],
           ),
           Spacer(),
-          widget.isFollowed
+          widget.didFollow
               ? Container(
                   width: 88,
                   height: 32,
@@ -140,9 +140,8 @@ class _UserCardState extends State<UserCard> {
                     onPressed: () {
                       setState(() {
                         // フォロー解除処理
-                        widget.isFollowed = false;
-                        _unfollowUser(widget.myselfUid,
-                            widget.user.uid ?? 'this must be followee uid');
+                        widget.didFollow = false;
+                        _unfollowUser(widget.myselfUid, widget.user.uid!);
                       });
                     },
                   ),
@@ -168,9 +167,8 @@ class _UserCardState extends State<UserCard> {
                     onPressed: () {
                       setState(() {
                         // フォロー処理
-                        widget.isFollowed = true;
-                        _followUser(widget.myselfUid,
-                            widget.user.uid ?? 'this must be followee uid');
+                        widget.didFollow = true;
+                        _followUser(widget.myselfUid, widget.user.uid!);
                       });
                     },
                   ),

--- a/lib/widgets/follow_follower_list_screen/user_card.dart
+++ b/lib/widgets/follow_follower_list_screen/user_card.dart
@@ -46,7 +46,7 @@ Future<String> _unfollowUser(String followerUid, String followeeUid) async {
     final String res = await doc.reference
         .delete()
         .then((_) => "success")
-        .onError((error, stackTrace) => "fail");
+        .catchError((_) => "fail");
     if (res == "fail") return "fail";
   }
   return 'success';

--- a/lib/widgets/follow_follower_list_screen/user_card.dart
+++ b/lib/widgets/follow_follower_list_screen/user_card.dart
@@ -42,13 +42,13 @@ Future<String> _unfollowUser(String followerUid, String followeeUid) async {
       .where('followee_id', isEqualTo: followeeUid)
       .get();
 
-  if (snapshot.docs.isEmpty || snapshot.docs.length != 1) return 'fail';
-
-  await FirebaseFirestore.instance
-      .collection("FOLLOW_FOLLOWER")
-      .doc(snapshot.docs[0].id)
-      .delete()
-      .catchError((e) => e);
+  for (QueryDocumentSnapshot doc in snapshot.docs) {
+    final String res = await doc.reference
+        .delete()
+        .then((_) => "success")
+        .onError((error, stackTrace) => "fail");
+    if (res == "fail") return "fail";
+  }
   return 'success';
 }
 


### PR DESCRIPTION
Firestoreの状況に合わせて、フォロー・フォロー解除ボタンの表示を出し分ける。

p.s.
フォロー・フォロー解除関数の引数に誤りがあったので、そこも修正した。