### PR TITLE
[fix] #116 タイムラインが無い時のエラーハンドリングを追加

### DIFF
--- a/lib/widgets/timeline_screen/dish_list.dart
+++ b/lib/widgets/timeline_screen/dish_list.dart
@@ -51,6 +51,11 @@ class _DiSHListState extends State<DiSHList> {
               if (posts.data == null) {
                 print("⌚ Fetch data now...");
                 return Center(child: CircularProgressIndicator());
+              } else if (posts.data!.length < 1) {
+                print("Nothing posts");
+                return Center(
+                  child: Text("知り合いをフォローしてみましょう！"),
+                );
               }
               return ListView(children: posts.data!);
             },


### PR DESCRIPTION
Firestoreにデータが無い時の処理を追加した。