### PR TITLE
[update] #122 画面に応じてフッターを閉じる

### DIFF
--- a/lib/screens/check_places_map.dart
+++ b/lib/screens/check_places_map.dart
@@ -202,6 +202,7 @@ class CheckPlacesMapState extends State<CheckPlacesMap> {
                   color: Colors.black,
                 ),
                 onPressed: () {
+                  widget.openFooter();
                   Navigator.pop(context);
                 },
               ),

--- a/lib/screens/check_places_map.dart
+++ b/lib/screens/check_places_map.dart
@@ -11,13 +11,17 @@ import 'package:dish/models/PinModel.dart';
 class CheckPlacesMap extends StatefulWidget {
   CheckPlacesMap({
     Key? key,
-    required this.latLng,
     required this.uid,
+    required this.latLng,
+    required this.openFooter,
+    required this.closeFooter,
     this.postInfo,
   });
   // のちにお店に修正
-  final LatLng latLng;
   final String uid;
+  final LatLng latLng;
+  final VoidCallback openFooter;
+  final VoidCallback closeFooter;
   PostModel? postInfo;
 
   @override
@@ -209,6 +213,8 @@ class CheckPlacesMapState extends State<CheckPlacesMap> {
                   resName: resName!,
                   postId: postId!,
                   postUser: postUser!,
+                  openFooter: widget.openFooter,
+                  closeFooter: widget.closeFooter,
                 )
               : Container(),
         ],

--- a/lib/screens/comment_screen.dart
+++ b/lib/screens/comment_screen.dart
@@ -295,6 +295,7 @@ class _CommentScreenState extends State<CommentScreen> {
           color: Colors.black,
         ),
         onPressed: () {
+          widget.openFooter();
           Navigator.pop(context);
         },
       ),

--- a/lib/screens/comment_screen.dart
+++ b/lib/screens/comment_screen.dart
@@ -13,10 +13,14 @@ class CommentScreen extends StatefulWidget {
     Key? key,
     required this.myUid,
     required this.postId,
+    required this.openFooter,
+    required this.closeFooter,
   }) : super(key: key);
 
   final String myUid;
   final String postId;
+  final VoidCallback openFooter;
+  final VoidCallback closeFooter;
 
   @override
   _CommentScreenState createState() => _CommentScreenState();
@@ -233,7 +237,11 @@ class _CommentScreenState extends State<CommentScreen> {
       content: data["content"],
       timestamp: DateFormat("yyyy/MM/dd").format(data["timestamp"].toDate()),
     );
-    return CommentCard(commentInfo: commentInfo);
+    return CommentCard(
+      commentInfo: commentInfo,
+      openFooter: widget.openFooter,
+      closeFooter: widget.closeFooter,
+    );
   }
 
   Future<User> _getUser(String uid) async {

--- a/lib/screens/display_posts_screen.dart
+++ b/lib/screens/display_posts_screen.dart
@@ -13,10 +13,14 @@ class DisplayPostsScreen extends StatefulWidget {
     Key? key,
     required this.user,
     required this.postId,
+    required this.openFooter,
+    required this.closeFooter,
   }) : super(key: key);
 
   final User user;
   final String postId;
+  final VoidCallback openFooter;
+  final VoidCallback closeFooter;
 
   @override
   _DisplayPostsScreenState createState() => _DisplayPostsScreenState();
@@ -40,6 +44,8 @@ class _DisplayPostsScreenState extends State<DisplayPostsScreen> {
               child: DishPost(
                 postInfo: _postInfo!,
                 uid: widget.user.uid!,
+                openFooter: widget.openFooter,
+                closeFooter: widget.closeFooter,
               ),
             )
           : Center(child: CircularProgressIndicator()),

--- a/lib/screens/follow_list_screen.dart
+++ b/lib/screens/follow_list_screen.dart
@@ -10,9 +10,13 @@ class FollowListScreen extends StatefulWidget {
   const FollowListScreen({
     Key? key,
     required this.uid,
+    required this.openFooter,
+    required this.closeFooter,
   }) : super(key: key);
 
   final String uid;
+  final VoidCallback openFooter;
+  final VoidCallback closeFooter;
 
   @override
   _FollowListScreenState createState() => _FollowListScreenState();
@@ -43,6 +47,8 @@ class _FollowListScreenState extends State<FollowListScreen> {
               user: _userList[index]["user"],
               didFollow: _userList[index]["didFollow"],
               myselfUid: widget.uid,
+              openFooter: widget.openFooter,
+              closeFooter: widget.closeFooter,
             );
           },
           separatorBuilder: (_, __) => SimpleDivider(height: 1.0),

--- a/lib/screens/follower_list_screen.dart
+++ b/lib/screens/follower_list_screen.dart
@@ -10,9 +10,13 @@ class FollowerListScreen extends StatefulWidget {
   const FollowerListScreen({
     Key? key,
     required this.uid,
+    required this.openFooter,
+    required this.closeFooter,
   }) : super(key: key);
 
   final String uid;
+  final VoidCallback openFooter;
+  final VoidCallback closeFooter;
 
   @override
   _FollowerListScreenState createState() => _FollowerListScreenState();
@@ -43,6 +47,8 @@ class _FollowerListScreenState extends State<FollowerListScreen> {
               user: _userList[index]["user"],
               didFollow: _userList[index]["didFollow"],
               myselfUid: widget.uid,
+              openFooter: widget.openFooter,
+              closeFooter: widget.closeFooter,
             );
           },
           separatorBuilder: (_, __) => SimpleDivider(height: 1.0),

--- a/lib/screens/post_screen.dart
+++ b/lib/screens/post_screen.dart
@@ -16,7 +16,12 @@ import 'package:dish/widgets/post_screen/star_review.dart';
 import 'package:dish/configs/constant_colors.dart';
 
 class PostScreen extends StatefulWidget {
-  const PostScreen({Key? key}) : super(key: key);
+  const PostScreen({
+    Key? key,
+    required this.openFooter,
+  }) : super(key: key);
+
+  final VoidCallback openFooter;
 
   @override
   _PostScreenState createState() => _PostScreenState();
@@ -272,9 +277,11 @@ class _PostScreenState extends State<PostScreen> {
             );
             if (result) {
               // 途中の投稿を保存する処理
+              widget.openFooter();
               Navigator.pop(context);
             }
           } else {
+            widget.openFooter();
             Navigator.pop(context);
           }
         },
@@ -295,6 +302,7 @@ class _PostScreenState extends State<PostScreen> {
           onPressed: () async {
             if (!_formKey.currentState!.validate() ||
                 selectedImageFiles.isEmpty) return;
+            widget.openFooter();
             Navigator.pop(context);
 
             final List<String> URLs =

--- a/lib/screens/post_screen.dart
+++ b/lib/screens/post_screen.dart
@@ -16,12 +16,7 @@ import 'package:dish/widgets/post_screen/star_review.dart';
 import 'package:dish/configs/constant_colors.dart';
 
 class PostScreen extends StatefulWidget {
-  const PostScreen({
-    Key? key,
-    required this.openFooter,
-  }) : super(key: key);
-
-  final VoidCallback openFooter;
+  const PostScreen({Key? key}) : super(key: key);
 
   @override
   _PostScreenState createState() => _PostScreenState();
@@ -277,11 +272,9 @@ class _PostScreenState extends State<PostScreen> {
             );
             if (result) {
               // 途中の投稿を保存する処理
-              widget.openFooter();
               Navigator.pop(context);
             }
           } else {
-            widget.openFooter();
             Navigator.pop(context);
           }
         },
@@ -302,7 +295,6 @@ class _PostScreenState extends State<PostScreen> {
           onPressed: () async {
             if (!_formKey.currentState!.validate() ||
                 selectedImageFiles.isEmpty) return;
-            widget.openFooter();
             Navigator.pop(context);
 
             final List<String> URLs =

--- a/lib/screens/profile_screen.dart
+++ b/lib/screens/profile_screen.dart
@@ -14,10 +14,14 @@ class ProfileScreen extends StatefulWidget {
   const ProfileScreen({
     Key? key,
     required this.uid,
+    required this.openFooter,
+    required this.closeFooter,
     this.popUntilFirstScreen,
   }) : super(key: key);
 
   final String uid;
+  final VoidCallback openFooter;
+  final VoidCallback closeFooter;
   final VoidCallback? popUntilFirstScreen;
 
   @override
@@ -116,7 +120,12 @@ class _ProfileScreenState extends State<ProfileScreen> {
                     print("⌚ Fetch data now...");
                     return Center(child: CircularProgressIndicator());
                   }
-                  return ProfileField(uid: widget.uid, user: user.data!);
+                  return ProfileField(
+                    uid: widget.uid,
+                    user: user.data!,
+                    openFooter: widget.openFooter,
+                    closeFooter: widget.closeFooter,
+                  );
                 },
               ),
               const SizedBox(height: 24),
@@ -130,7 +139,12 @@ class _ProfileScreenState extends State<ProfileScreen> {
                     print("⌚ Fetch data now...");
                     return Center(child: CircularProgressIndicator());
                   }
-                  return PostsField(user: _myself!, posts: posts.data!);
+                  return PostsField(
+                    user: _myself!,
+                    posts: posts.data!,
+                    openFooter: widget.openFooter,
+                    closeFooter: widget.closeFooter,
+                  );
                 },
               ),
             ],

--- a/lib/screens/search_screen.dart
+++ b/lib/screens/search_screen.dart
@@ -7,7 +7,14 @@ import 'package:dish/widgets/common/simple_divider.dart';
 import 'package:dish/widgets/search_screen/user_card.dart';
 
 class SearchScreen extends StatefulWidget {
-  const SearchScreen({Key? key}) : super(key: key);
+  const SearchScreen({
+    Key? key,
+    required this.openFooter,
+    required this.closeFooter,
+  }) : super(key: key);
+
+  final VoidCallback openFooter;
+  final VoidCallback closeFooter;
 
   @override
   _SearchScreenState createState() => _SearchScreenState();
@@ -76,6 +83,8 @@ class _SearchScreenState extends State<SearchScreen> {
 
               return UserCard(
                 user: _searchResult[index],
+                openFooter: widget.openFooter,
+                closeFooter: widget.closeFooter,
               );
             },
             separatorBuilder: (_, __) => SimpleDivider(height: 1.0),

--- a/lib/screens/timeline_screen.dart
+++ b/lib/screens/timeline_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:ui';
+
 import 'package:flutter/material.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
@@ -5,7 +7,14 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:dish/widgets/timeline_screen/dish_list.dart';
 
 class Timeline extends StatefulWidget {
-  const Timeline({Key? key}) : super(key: key);
+  const Timeline({
+    Key? key,
+    required this.openFooter,
+    required this.closeFooter,
+  }) : super(key: key);
+
+  final VoidCallback openFooter;
+  final VoidCallback closeFooter;
 
   @override
   _TimelineState createState() => _TimelineState();
@@ -26,7 +35,11 @@ class _TimelineState extends State<Timeline> {
   Widget build(BuildContext context) {
     return new Scaffold(
       appBar: _buildAppBar(_userIconPath),
-      body: DiSHList(uid: uid!),
+      body: DiSHList(
+        uid: uid!,
+        openFooter: widget.openFooter,
+        closeFooter: widget.closeFooter,
+      ),
     );
   }
 

--- a/lib/widgets/check_places_map/display_image.dart
+++ b/lib/widgets/check_places_map/display_image.dart
@@ -9,12 +9,16 @@ class DisplayImage extends StatelessWidget {
     required this.resName,
     required this.postId,
     required this.postUser,
+    required this.openFooter,
+    required this.closeFooter,
   }) : super(key: key);
 
   final String imagePath;
   final String resName;
   final String postId;
   final User postUser;
+  final VoidCallback openFooter;
+  final VoidCallback closeFooter;
 
   @override
   Widget build(BuildContext context) {
@@ -33,6 +37,8 @@ class DisplayImage extends StatelessWidget {
                     builder: (_) => DisplayPostsScreen(
                       postId: postId,
                       user: postUser,
+                      openFooter: openFooter,
+                      closeFooter: closeFooter,
                     ),
                   ),
                 );

--- a/lib/widgets/comment_screen/comment_card.dart
+++ b/lib/widgets/comment_screen/comment_card.dart
@@ -8,9 +8,13 @@ class CommentCard extends StatelessWidget {
   const CommentCard({
     Key? key,
     required this.commentInfo,
+    required this.openFooter,
+    required this.closeFooter,
   }) : super(key: key);
 
   final Comment commentInfo;
+  final VoidCallback openFooter;
+  final VoidCallback closeFooter;
   final _replyText = "返信する";
 
   @override
@@ -28,8 +32,11 @@ class CommentCard extends StatelessWidget {
             onTap: () {
               Navigator.of(context).push(
                 MaterialPageRoute<void>(
-                  builder: (BuildContext context) =>
-                      ProfileScreen(uid: commentInfo.user.uid!),
+                  builder: (BuildContext context) => ProfileScreen(
+                    uid: commentInfo.user.uid!,
+                    openFooter: openFooter,
+                    closeFooter: closeFooter,
+                  ),
                 ),
               );
             },

--- a/lib/widgets/follow_follower_list_screen/user_card.dart
+++ b/lib/widgets/follow_follower_list_screen/user_card.dart
@@ -11,11 +11,15 @@ class UserCard extends StatefulWidget {
     required this.user,
     required this.didFollow,
     required this.myselfUid,
+    required this.openFooter,
+    required this.closeFooter,
   }) : super(key: key);
 
   final User user;
   bool didFollow;
   final String myselfUid;
+  final VoidCallback openFooter;
+  final VoidCallback closeFooter;
 
   @override
   _UserCardState createState() => _UserCardState();
@@ -72,7 +76,11 @@ class _UserCardState extends State<UserCard> {
               Navigator.push(
                 context,
                 MaterialPageRoute(
-                    builder: (_) => ProfileScreen(uid: widget.user.uid!)),
+                    builder: (_) => ProfileScreen(
+                          uid: widget.user.uid!,
+                          openFooter: widget.openFooter,
+                          closeFooter: widget.closeFooter,
+                        )),
               );
             },
             child: Container(

--- a/lib/widgets/profile_screen/post_card.dart
+++ b/lib/widgets/profile_screen/post_card.dart
@@ -11,10 +11,14 @@ class PostCard extends StatelessWidget {
     Key? key,
     required this.user,
     required this.post,
+    required this.openFooter,
+    required this.closeFooter,
   }) : super(key: key);
 
   final User user;
   final Post post;
+  final VoidCallback openFooter;
+  final VoidCallback closeFooter;
 
   @override
   Widget build(BuildContext context) {
@@ -32,6 +36,8 @@ class PostCard extends StatelessWidget {
             return DisplayPostsScreen(
               user: user,
               postId: post.postId,
+              openFooter: openFooter,
+              closeFooter: closeFooter,
             );
           }),
         );

--- a/lib/widgets/profile_screen/posts_field.dart
+++ b/lib/widgets/profile_screen/posts_field.dart
@@ -10,10 +10,14 @@ class PostsField extends StatelessWidget {
     Key? key,
     required this.user,
     required this.posts,
+    required this.openFooter,
+    required this.closeFooter,
   });
 
   final List<Post> posts;
   final User user;
+  final VoidCallback openFooter;
+  final VoidCallback closeFooter;
 
   @override
   Widget build(BuildContext context) {
@@ -24,7 +28,12 @@ class PostsField extends StatelessWidget {
         alignment: WrapAlignment.spaceBetween,
         spacing: 8,
         children: posts.map((post) {
-          return PostCard(user: user, post: post);
+          return PostCard(
+            user: user,
+            post: post,
+            openFooter: openFooter,
+            closeFooter: closeFooter,
+          );
         }).toList(),
       );
     } else {

--- a/lib/widgets/profile_screen/profile_field.dart
+++ b/lib/widgets/profile_screen/profile_field.dart
@@ -12,10 +12,14 @@ class ProfileField extends StatefulWidget {
     Key? key,
     required this.uid,
     required this.user,
+    required this.openFooter,
+    required this.closeFooter,
   });
 
   final String uid;
   final User user;
+  final VoidCallback openFooter;
+  final VoidCallback closeFooter;
 
   @override
   _ProfileFieldState createState() => _ProfileFieldState();
@@ -99,7 +103,11 @@ class _ProfileFieldState extends State<ProfileField> {
                       Navigator.push(
                         context,
                         MaterialPageRoute(builder: (_) {
-                          return FollowerListScreen(uid: widget.uid);
+                          return FollowerListScreen(
+                            uid: widget.uid,
+                            openFooter: widget.openFooter,
+                            closeFooter: widget.closeFooter,
+                          );
                         }),
                       );
                     },
@@ -119,7 +127,11 @@ class _ProfileFieldState extends State<ProfileField> {
                       Navigator.push(
                         context,
                         MaterialPageRoute(builder: (_) {
-                          return FollowListScreen(uid: widget.uid);
+                          return FollowListScreen(
+                            uid: widget.uid,
+                            openFooter: widget.openFooter,
+                            closeFooter: widget.closeFooter,
+                          );
                         }),
                       );
                     },

--- a/lib/widgets/routes/route.dart
+++ b/lib/widgets/routes/route.dart
@@ -37,15 +37,29 @@ class _RouteWidgetState extends State<RouteWidget> {
     "Profile": GlobalKey<NavigatorState>(),
   };
   String _currentPage = "Home";
+  bool isOpenFooter = true;
   final String uid = FirebaseAuth.instance.currentUser!.uid;
+
+  void openFooter() {
+    setState(() {
+      isOpenFooter = true;
+    });
+  }
+
+  void closeFooter() {
+    setState(() {
+      isOpenFooter = false;
+    });
+  }
 
   Future<void> _selectTab(String tabItem, int index) async {
     /* フッターを隠したいページは、bodyを切り替えずに直接pushする */
     if (tabItem == "NewPost") {
+      closeFooter();
       Navigator.push(
         context,
         MaterialPageRoute(
-          builder: (_) => PostScreen(),
+          builder: (_) => PostScreen(openFooter: openFooter),
         ),
       );
       return;
@@ -112,26 +126,28 @@ class _RouteWidgetState extends State<RouteWidget> {
               )
               .toList(),
         ),
-        bottomNavigationBar: BottomNavigationBar(
-          unselectedItemColor: Colors.black45,
-          selectedItemColor: Colors.black87,
-          showUnselectedLabels: false,
-          showSelectedLabels: false,
-          onTap: (index) {
-            _selectTab(_pageKeys[index], index);
-          },
-          currentIndex: _pageKeys.indexOf(_currentPage),
-          items: _pageKeys
-              .map(
-                (key) => BottomNavigationBarItem(
-                  icon: Icon(_bottomNaviItems[key]),
-                  label: "",
-                  tooltip: "",
-                ),
+        bottomNavigationBar: isOpenFooter
+            ? BottomNavigationBar(
+                unselectedItemColor: Colors.black45,
+                selectedItemColor: Colors.black87,
+                showUnselectedLabels: false,
+                showSelectedLabels: false,
+                onTap: (index) {
+                  _selectTab(_pageKeys[index], index);
+                },
+                currentIndex: _pageKeys.indexOf(_currentPage),
+                items: _pageKeys
+                    .map(
+                      (key) => BottomNavigationBarItem(
+                        icon: Icon(_bottomNaviItems[key]),
+                        label: "",
+                        tooltip: "",
+                      ),
+                    )
+                    .toList(),
+                type: BottomNavigationBarType.fixed,
               )
-              .toList(),
-          type: BottomNavigationBarType.fixed,
-        ),
+            : null,
       ),
     );
   }

--- a/lib/widgets/routes/route.dart
+++ b/lib/widgets/routes/route.dart
@@ -55,11 +55,10 @@ class _RouteWidgetState extends State<RouteWidget> {
   Future<void> _selectTab(String tabItem, int index) async {
     /* フッターを隠したいページは、bodyを切り替えずに直接pushする */
     if (tabItem == "NewPost") {
-      closeFooter();
       Navigator.push(
         context,
         MaterialPageRoute(
-          builder: (_) => PostScreen(openFooter: openFooter),
+          builder: (_) => PostScreen(),
         ),
       );
       return;
@@ -71,11 +70,13 @@ class _RouteWidgetState extends State<RouteWidget> {
         context,
         MaterialPageRoute(
           builder: (_) => CheckPlacesMap(
+            uid: uid,
             latLng: LatLng(
               posi.latitude,
               posi.longitude,
             ),
-            uid: uid,
+            openFooter: openFooter,
+            closeFooter: closeFooter,
           ),
         ),
       );
@@ -119,6 +120,8 @@ class _RouteWidgetState extends State<RouteWidget> {
           children: _pageKeys
               .map(
                 (key) => TabNavigator(
+                  openFooter: openFooter,
+                  closeFooter: closeFooter,
                   popUntilFirstScreen: popUntilFirstScreen,
                   navigatorKey: _navigatorKeys[key]!,
                   tabItem: key,

--- a/lib/widgets/routes/tab_navigator.dart
+++ b/lib/widgets/routes/tab_navigator.dart
@@ -9,11 +9,15 @@ import 'package:dish/screens/search_screen.dart';
 
 class TabNavigator extends StatelessWidget {
   TabNavigator({
+    required this.openFooter,
+    required this.closeFooter,
     required this.popUntilFirstScreen,
     required this.navigatorKey,
     required this.tabItem,
   });
 
+  final VoidCallback openFooter;
+  final VoidCallback closeFooter;
   final VoidCallback popUntilFirstScreen;
   final GlobalKey<NavigatorState> navigatorKey;
   final String tabItem;
@@ -25,10 +29,16 @@ class TabNavigator extends StatelessWidget {
 
     switch (tabItem) {
       case "Home":
-        child = Timeline();
+        child = Timeline(
+          openFooter: openFooter,
+          closeFooter: closeFooter,
+        );
         break;
       case "Search":
-        child = SearchScreen();
+        child = SearchScreen(
+          openFooter: openFooter,
+          closeFooter: closeFooter,
+        );
         break;
       // case "NewPost":
       //   child = PostScreen();
@@ -40,6 +50,8 @@ class TabNavigator extends StatelessWidget {
         child = ProfileScreen(
           uid: uid,
           popUntilFirstScreen: popUntilFirstScreen,
+          openFooter: openFooter,
+          closeFooter: closeFooter,
         );
         break;
       default:

--- a/lib/widgets/search_screen/user_card.dart
+++ b/lib/widgets/search_screen/user_card.dart
@@ -8,9 +8,13 @@ class UserCard extends StatelessWidget {
   const UserCard({
     Key? key,
     required this.user,
+    required this.openFooter,
+    required this.closeFooter,
   }) : super(key: key);
 
   final User user;
+  final VoidCallback openFooter;
+  final VoidCallback closeFooter;
 
   @override
   Widget build(BuildContext context) {
@@ -18,7 +22,12 @@ class UserCard extends StatelessWidget {
       onTap: () {
         Navigator.push(
           context,
-          MaterialPageRoute(builder: (_) => ProfileScreen(uid: user.uid!)),
+          MaterialPageRoute(
+              builder: (_) => ProfileScreen(
+                    uid: user.uid!,
+                    openFooter: openFooter,
+                    closeFooter: closeFooter,
+                  )),
         );
       },
       child: Container(

--- a/lib/widgets/timeline_screen/dish_list.dart
+++ b/lib/widgets/timeline_screen/dish_list.dart
@@ -11,9 +11,13 @@ class DiSHList extends StatefulWidget {
   const DiSHList({
     Key? key,
     required this.uid,
+    required this.openFooter,
+    required this.closeFooter,
   }) : super(key: key);
 
   final String uid;
+  final VoidCallback openFooter;
+  final VoidCallback closeFooter;
 
   @override
   _DiSHListState createState() => _DiSHListState();
@@ -94,7 +98,12 @@ class _DiSHListState extends State<DiSHList> {
         "taste": postRawData["evaluation"]["taste"] + 0.0,
       },
     );
-    return DishPost(uid: postRawData["uid"], postInfo: postInfo);
+    return DishPost(
+      uid: postRawData["uid"],
+      postInfo: postInfo,
+      openFooter: widget.openFooter,
+      closeFooter: widget.closeFooter,
+    );
   }
 
   Future<User> _getUser(String uid) async {

--- a/lib/widgets/timeline_screen/post.dart
+++ b/lib/widgets/timeline_screen/post.dart
@@ -177,6 +177,7 @@ class _DishPostState extends State<DishPost> {
                     onPrimary: Colors.white,
                   ),
                   onPressed: () {
+                    widget.closeFooter();
                     Navigator.push(
                       context,
                       MaterialPageRoute(builder: (_) {

--- a/lib/widgets/timeline_screen/post.dart
+++ b/lib/widgets/timeline_screen/post.dart
@@ -244,6 +244,7 @@ class _DishPostState extends State<DishPost> {
             // コメント画面に遷移
             // 実際はコメントの情報を引数として渡す
             print('コメント画面に遷移');
+            widget.closeFooter();
             Navigator.push(
               context,
               MaterialPageRoute(

--- a/lib/widgets/timeline_screen/post.dart
+++ b/lib/widgets/timeline_screen/post.dart
@@ -18,7 +18,12 @@ class DishPost extends StatefulWidget {
     Key? key,
     required this.uid,
     required this.postInfo,
+    required this.openFooter,
+    required this.closeFooter,
   });
+
+  final VoidCallback openFooter;
+  final VoidCallback closeFooter;
 
   @override
   _DishPostState createState() => _DishPostState();
@@ -119,7 +124,11 @@ class _DishPostState extends State<DishPost> {
                   Navigator.push(
                     context,
                     MaterialPageRoute(
-                      builder: (_) => ProfileScreen(uid: widget.uid),
+                      builder: (_) => ProfileScreen(
+                        uid: widget.uid,
+                        openFooter: widget.openFooter,
+                        closeFooter: widget.closeFooter,
+                      ),
                     ),
                   );
                 },
@@ -175,6 +184,8 @@ class _DishPostState extends State<DishPost> {
                           latLng: widget.postInfo.map,
                           uid: widget.uid,
                           postInfo: widget.postInfo,
+                          openFooter: widget.openFooter,
+                          closeFooter: widget.closeFooter,
                         );
                       }),
                     );
@@ -239,6 +250,8 @@ class _DishPostState extends State<DishPost> {
                 builder: (_) => CommentScreen(
                   myUid: widget.uid,
                   postId: widget.postInfo.id,
+                  openFooter: widget.openFooter,
+                  closeFooter: widget.closeFooter,
                 ),
               ),
             );


### PR DESCRIPTION
フッターの表示・非表示をフラグで管理して、そのフラグを切り替える関数を各ウィジェットに渡すようにしている。
ウィジェットは遷移する画面に応じてフラグを制御する関数を呼び出し、フッターの表示・非表示を制御する。

「マップで見る」から戻るときだけ謎の例外処理が走るけど、とりあえずPR出しとく。