### PR TITLE
[add] #49 スプラッシュ画面の追加

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -40,6 +40,12 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
+  flutter_native_splash: ^1.3.2
+
+flutter_native_splash:
+  color: "#FFFFFF"
+  image: assets/images/splash.png
+  fullscreen: true
 
 flutter:
   uses-material-design: true


### PR DESCRIPTION
スプラッシュとして表示したいロゴを以下の名前で追加する。
`assets/images/splash.png`

画像を追加したら、コマンドを入力する。
```zsh
flutter pub run flutter_native_splash:create
```

ロゴが確定したら、上のコマンドを入力した後の状態で再びコミットする。